### PR TITLE
Address various warnings

### DIFF
--- a/src/encode_u16.rs
+++ b/src/encode_u16.rs
@@ -96,7 +96,7 @@ fn sanity_encode() {
     assert_enc("Ꭰ Ꭱ Ꭲ Ꭳ Ꭴ Ꭵ Ꭶ Ꭷ Ꭸ Ꭹ");
     assert_enc("ἀ ἁ ἂ ἃ ἄ ἅ ἆ ἇ Ἀ Ἁ");
     assert_enc("                          ​ ‌ ‍ ‎ ‏ ‐ ");
-    assert_enc("‑ ‒ – — ― ‖ ‗ ‘ ’ ‚ ‛ “");;
+    assert_enc("‑ ‒ – — ― ‖ ‗ ‘ ’ ‚ ‛ “");
     assert_enc("    ⃐ ⃑ ⃒ ⃓ ⃔ ⃕ ⃖ ⃗ ⃘ ⃙ ⃚ ⃛ ⃜ ⃝ ⃞ ⃟ ⃠ ⃡ ⃢ ⃣ ⃤ ⃥ ⃦ ⃧ ⃨ ⃩ ⃪ ");
 
     // Test that `\` gets escaped

--- a/src/encode_u16.rs
+++ b/src/encode_u16.rs
@@ -36,9 +36,9 @@ pub(crate) fn encode(encoder: &super::Encoder, v: &[u16]) -> String {
     loop {
         match c16 {
             // non-printable ascii
-            0x00...0x1F | helpers::BSLASH_U16 => helpers::escape_u8(&mut out, encoder, c16 as u8),
+            0x00..=0x1F | helpers::BSLASH_U16 => helpers::escape_u8(&mut out, encoder, c16 as u8),
             // leading surrogates
-            LEAD_MIN...LEAD_MAX => {
+            LEAD_MIN..=LEAD_MAX => {
                 let trail = match iter.next() {
                     Some(t) => *t,
                     None => {
@@ -59,7 +59,7 @@ pub(crate) fn encode(encoder: &super::Encoder, v: &[u16]) -> String {
                 out.push(char::from_u32(helpers::to_utf32(&buf)).unwrap());
             }
             // unpaired trailing surrogates
-            TRAIL_MIN...TRAIL_MAX => {
+            TRAIL_MIN..=TRAIL_MAX => {
                 // trail without a lead
                 helpers::escape_u16(&mut out, c16);
             }

--- a/src/encode_u8.rs
+++ b/src/encode_u8.rs
@@ -35,9 +35,8 @@ pub(crate) fn encode(encoder: &super::Encoder, v: &[u8]) -> String {
             let b = v[$i];
             match b {
                 helpers::BSLASH => helpers::escape_u8(&mut out, encoder, b),
-                0x20...0x7e => out.push(b as char), // visible ASCII
-                0x00...0x1F | 0x7f...0xFF => helpers::escape_u8(&mut out, encoder, b),
-                _ => unreachable!(),
+                0x20..=0x7e => out.push(b as char), // visible ASCII
+                0x00..=0x1F | 0x7f..=0xFF => helpers::escape_u8(&mut out, encoder, b),
             }
         }}}
 
@@ -97,10 +96,10 @@ pub(crate) fn encode(encoder: &super::Encoder, v: &[u8]) -> String {
                 }
                 3 => {
                     match (first, next!()) {
-                        (0xE0, 0xA0...0xBF)
-                        | (0xE1...0xEC, 0x80...0xBF)
-                        | (0xED, 0x80...0x9F)
-                        | (0xEE...0xEF, 0x80...0xBF) => {}
+                        (0xE0, 0xA0..=0xBF)
+                        | (0xE1..=0xEC, 0x80..=0xBF)
+                        | (0xED, 0x80..=0x9F)
+                        | (0xEE..=0xEF, 0x80..=0xBF) => {}
                         _ => escape_them!(), // orig: err!(Some(1))
                     }
                     if next!() & !CONT_MASK != TAG_CONT_U8 {
@@ -109,7 +108,7 @@ pub(crate) fn encode(encoder: &super::Encoder, v: &[u8]) -> String {
                 }
                 4 => {
                     match (first, next!()) {
-                        (0xF0, 0x90...0xBF) | (0xF1...0xF3, 0x80...0xBF) | (0xF4, 0x80...0x8F) => {}
+                        (0xF0, 0x90..=0xBF) | (0xF1..=0xF3, 0x80..=0xBF) | (0xF4, 0x80..=0x8F) => {}
                         _ => escape_them!(), //orig: err!(Some(1))
                     }
                     if next!() & !CONT_MASK != TAG_CONT_U8 {

--- a/src/encode_u8.rs
+++ b/src/encode_u8.rs
@@ -175,7 +175,7 @@ fn sanity_encode() {
     assert_enc("Ꭰ Ꭱ Ꭲ Ꭳ Ꭴ Ꭵ Ꭶ Ꭷ Ꭸ Ꭹ");
     assert_enc("ἀ ἁ ἂ ἃ ἄ ἅ ἆ ἇ Ἀ Ἁ");
     assert_enc("                          ​ ‌ ‍ ‎ ‏ ‐ ");
-    assert_enc("‑ ‒ – — ― ‖ ‗ ‘ ’ ‚ ‛ “");;
+    assert_enc("‑ ‒ – — ― ‖ ‗ ‘ ’ ‚ ‛ “");
     assert_enc("    ⃐ ⃑ ⃒ ⃓ ⃔ ⃕ ⃖ ⃗ ⃘ ⃙ ⃚ ⃛ ⃜ ⃝ ⃞ ⃟ ⃠ ⃡ ⃢ ⃣ ⃤ ⃥ ⃦ ⃧ ⃨ ⃩ ⃪ ");
 
     // Test that `\` gets escaped

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -26,7 +26,7 @@ fn from_hex(b: u8) -> u8 {
     (b as char).to_digit(16).unwrap() as u8
 }
 
-const SURROGATE_OFFSET: i64 = (0x1_0000 - (0xD800 << 10) - 0xDC00);
+const SURROGATE_OFFSET: i64 = 0x1_0000 - (0xD800 << 10) - 0xDC00;
 
 /// Convert from UTF-16 to UTF-32.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,7 @@ pub fn decode_u8(s: &str) -> Result<Vec<u8>, DecodeError> {
                     }
                 },
                 decode::PushGeneric::String(s) => {
-                    out.extend_from_slice(&s.as_bytes());
+                    out.extend_from_slice(s.as_bytes());
                     Ok(())
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,9 @@
 //! - [`encode_u16`](fn.encode_u16.html) and [`decode_u16`](fn.decode_u16.html)
 //!
 //! Also see the [project README](https://github.com/vitiral/stfu8) and consider starring it!
+
+#![forbid(unsafe_code)]
+
 #[macro_use]
 extern crate lazy_static;
 extern crate regex;

--- a/tests/sanity.rs
+++ b/tests/sanity.rs
@@ -98,7 +98,7 @@ fn sanity_roundtrip() {
     assert_round_str(
         "                          ​ ‌ ‍ ‎ ‏ ‐ ",
     );
-    assert_round_str("‑ ‒ – — ― ‖ ‗ ‘ ’ ‚ ‛ “");;
+    assert_round_str("‑ ‒ – — ― ‖ ‗ ‘ ’ ‚ ‛ “");
     assert_round_str("    ⃐ ⃑ ⃒ ⃓ ⃔ ⃕ ⃖ ⃗ ⃘ ⃙ ⃚ ⃛ ⃜ ⃝ ⃞ ⃟ ⃠ ⃡ ⃢ ⃣ ⃤ ⃥ ⃦ ⃧ ⃨ ⃩ ⃪ ");
 }
 


### PR DESCRIPTION
Update code to build cleanly

- Rust 2018 inclusive range syntax
- Remove redundant punctuation
- Forbid unsafe code

Side-effect from a dependency audit.