### PR TITLE
Remove dependency to regex crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,6 @@ repository = "https://github.com/vitiral/stfu8"
 travis-ci = { repository = "vitiral/stfu8" }
 appveyor = { repository = "vitiral/stfu8" }
 
-[dependencies]
-regex = ">=0.2.0"
-lazy_static = ">=1.0.0"
-
 [dev-dependencies]
 pretty_assertions = "1.1"
 proptest = "1.0"

--- a/src/encode_u8.rs
+++ b/src/encode_u8.rs
@@ -63,10 +63,9 @@ pub(crate) fn encode(encoder: &super::Encoder, v: &[u8]) -> String {
         macro_rules! next {
             () => {{
                 index += 1;
-                // we needed data, but there was none: error!
                 if index >= len {
-                    index -= 1; // added by me
-                    escape_them!(); // orig: err!(None)
+                    index -= 1;
+                    escape_them!();
                 }
                 v[index]
             }};

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -14,31 +14,6 @@ use std::u32;
 pub(crate) const BSLASH: u8 = b'\\';
 pub(crate) const BSLASH_U16: u16 = BSLASH as u16;
 
-/// create `u8` from two bytes of hex
-#[inline(always)]
-pub(crate) fn from_hex2(hex2: &[u8]) -> Result<u8, ()> {
-    debug_assert_eq!(2, hex2.len());
-    Ok((from_hex(hex2[0])? << 4) + from_hex(hex2[1])?)
-}
-
-/// create `u32` from six bytes of hex
-#[inline(always)]
-pub(crate) fn from_hex6(hex6: &[u8]) -> Result<u32, ()> {
-    debug_assert_eq!(6, hex6.len());
-    Ok(((from_hex(hex6[0])? as u32) << 20)
-        + ((from_hex(hex6[1])? as u32) << 16)
-        + ((from_hex(hex6[2])? as u32) << 12)
-        + ((from_hex(hex6[3])? as u32) << 8)
-        + ((from_hex(hex6[4])? as u32) << 4)
-        + (from_hex(hex6[5])? as u32))
-}
-
-#[inline(always)]
-/// Convert a hexidecimal character (`0-F`) into it's corresponding numerical value (0-15)
-fn from_hex(b: u8) -> Result<u8, ()> {
-    (b as char).to_digit(16).map_or(Err(()), |x| Ok(x as u8))
-}
-
 const SURROGATE_OFFSET: i64 = 0x1_0000 - (0xD800 << 10) - 0xDC00;
 
 /// Convert from UTF-16 to UTF-32.
@@ -111,25 +86,6 @@ mod tests {
         }
 
         assert_eq!(expect_suplimental, got_suplimental);
-    }
-
-    #[test]
-    fn test_hex2() {
-        assert_eq!(0, from_hex2("00".as_bytes()).unwrap());
-        assert_eq!(15, from_hex2("0F".as_bytes()).unwrap());
-        assert_eq!(15, from_hex2("0f".as_bytes()).unwrap());
-        assert_eq!(16, from_hex2("10".as_bytes()).unwrap());
-        assert_eq!(31, from_hex2("1F".as_bytes()).unwrap());
-        assert_eq!(31, from_hex2("1f".as_bytes()).unwrap());
-    }
-
-    #[test]
-    fn test_hex6() {
-        assert_eq!(0, from_hex6("000000".as_bytes()).unwrap());
-        assert_eq!(15, from_hex6("00000F".as_bytes()).unwrap());
-        assert_eq!(16, from_hex6("000010".as_bytes()).unwrap());
-        assert_eq!(31, from_hex6("00001f".as_bytes()).unwrap());
-        assert_eq!(2039583, from_hex6("1f1f1f".as_bytes()).unwrap());
     }
 
     #[test]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -15,15 +15,28 @@ pub(crate) const BSLASH: u8 = b'\\';
 pub(crate) const BSLASH_U16: u16 = BSLASH as u16;
 
 /// create `u8` from two bytes of hex
-pub(crate) fn from_hex2(hex2: &[u8]) -> u8 {
+#[inline(always)]
+pub(crate) fn from_hex2(hex2: &[u8]) -> Result<u8, ()> {
     debug_assert_eq!(2, hex2.len());
-    (from_hex(hex2[0]) << 4) + from_hex(hex2[1])
+    Ok((from_hex(hex2[0])? << 4) + from_hex(hex2[1])?)
+}
+
+/// create `u32` from six bytes of hex
+#[inline(always)]
+pub(crate) fn from_hex6(hex6: &[u8]) -> Result<u32, ()> {
+    debug_assert_eq!(6, hex6.len());
+    Ok(((from_hex(hex6[0])? as u32) << 20)
+        + ((from_hex(hex6[1])? as u32) << 16)
+        + ((from_hex(hex6[2])? as u32) << 12)
+        + ((from_hex(hex6[3])? as u32) << 8)
+        + ((from_hex(hex6[4])? as u32) << 4)
+        + (from_hex(hex6[5])? as u32))
 }
 
 #[inline(always)]
 /// Convert a hexidecimal character (`0-F`) into it's corresponding numerical value (0-15)
-fn from_hex(b: u8) -> u8 {
-    (b as char).to_digit(16).unwrap() as u8
+fn from_hex(b: u8) -> Result<u8, ()> {
+    (b as char).to_digit(16).map_or(Err(()), |x| Ok(x as u8))
 }
 
 const SURROGATE_OFFSET: i64 = 0x1_0000 - (0xD800 << 10) - 0xDC00;
@@ -93,11 +106,30 @@ mod tests {
             }
             assert_eq!(expected, c16);
 
-            let c32 = to_utf32(&c16);
+            let c32 = to_utf32(c16);
             assert_eq!(c as u32, c32);
         }
 
         assert_eq!(expect_suplimental, got_suplimental);
+    }
+
+    #[test]
+    fn test_hex2() {
+        assert_eq!(0, from_hex2("00".as_bytes()).unwrap());
+        assert_eq!(15, from_hex2("0F".as_bytes()).unwrap());
+        assert_eq!(15, from_hex2("0f".as_bytes()).unwrap());
+        assert_eq!(16, from_hex2("10".as_bytes()).unwrap());
+        assert_eq!(31, from_hex2("1F".as_bytes()).unwrap());
+        assert_eq!(31, from_hex2("1f".as_bytes()).unwrap());
+    }
+
+    #[test]
+    fn test_hex6() {
+        assert_eq!(0, from_hex6("000000".as_bytes()).unwrap());
+        assert_eq!(15, from_hex6("00000F".as_bytes()).unwrap());
+        assert_eq!(16, from_hex6("000010".as_bytes()).unwrap());
+        assert_eq!(31, from_hex6("00001f".as_bytes()).unwrap());
+        assert_eq!(2039583, from_hex6("1f1f1f".as_bytes()).unwrap());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,11 @@ pub fn decode_u8(s: &str) -> Result<Vec<u8>, DecodeError> {
                     out.extend_from_slice(s.as_bytes());
                     Ok(())
                 }
+                decode::PushGeneric::Char(c) => {
+                    let mut b = [0u8; 4];
+                    out.extend_from_slice(c.encode_utf8(&mut b).as_bytes());
+                    Ok(())
+                }
             }
         };
         decode::decode_generic(f, s)?;
@@ -288,6 +293,11 @@ pub fn decode_u16(s: &str) -> Result<Vec<u16>, DecodeError> {
                         let mut buf = [0u16; 2];
                         out.extend_from_slice(c.encode_utf16(&mut buf));
                     }
+                    Ok(())
+                }
+                decode::PushGeneric::Char(c) => {
+                    let mut b = [0u16; 2];
+                    out.extend_from_slice(c.encode_utf16(&mut b));
                     Ok(())
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,6 @@
 
 #![forbid(unsafe_code)]
 
-#[macro_use]
-extern crate lazy_static;
-extern crate regex;
-
 #[cfg(test)]
 #[macro_use]
 extern crate pretty_assertions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,11 +225,6 @@ pub fn decode_u8(s: &str) -> Result<Vec<u8>, DecodeError> {
                     out.extend_from_slice(s.as_bytes());
                     Ok(())
                 }
-                decode::PushGeneric::Char(c) => {
-                    let mut b = [0u8; 4];
-                    out.extend_from_slice(c.encode_utf8(&mut b).as_bytes());
-                    Ok(())
-                }
             }
         };
         decode::decode_generic(f, s)?;
@@ -293,11 +288,6 @@ pub fn decode_u16(s: &str) -> Result<Vec<u16>, DecodeError> {
                         let mut buf = [0u16; 2];
                         out.extend_from_slice(c.encode_utf16(&mut buf));
                     }
-                    Ok(())
-                }
-                decode::PushGeneric::Char(c) => {
-                    let mut b = [0u16; 2];
-                    out.extend_from_slice(c.encode_utf16(&mut b));
                     Ok(())
                 }
             }


### PR DESCRIPTION
Reimplement the `decode_generic` without regular expressions. Just `find` backslashes and process the following characters. 

I used stfu8 in a CLI executable and this resulted in a binary size of ~ 1.8MB. By changing stfu8 to work without regex, the binary size dropped to ~ 700KB.

This also adds two new `DecoderErrorKind` enums: 
* `HexNumberToShort` (not enough characters after a `\x` or `\u`)
* `InvalidHexDigit`

This two errors would previously be reported as `UnescapedSlash`.

This PR also contains a commit for `cargo fmt` and one for `cargo clippy` (SCNR).